### PR TITLE
wow such bugfix, prevent many crash due to unicode uname

### DIFF
--- a/doge/core.py
+++ b/doge/core.py
@@ -181,7 +181,7 @@ class Doge(object):
         ret += self.get_processes()[:2]
 
         # Lowercase the data, and set it into the wordlist.
-        self.words.extend(map(str.lower, ret))
+        self.words.extend(map(lambda x: str.lower(x).decode('utf-8'), ret))
 
     def get_stdin_data(self):
         """


### PR DESCRIPTION
Systems with unicode characters returned from os.uname() crash
This patch correctly displays such characters. so amaze
