### PR TITLE
Added missing space in error message

### DIFF
--- a/doge/core.py
+++ b/doge/core.py
@@ -481,7 +481,7 @@ def main():
         if not lang.endswith('UTF-8'):
             print(
                 "wow error: locale '{0}' is not UTF-8.  ".format(lang) +
-                "doge needs UTF-8 to print Shibe.  Please set your system to"
+                "doge needs UTF-8 to print Shibe.  Please set your system to "
                 "use a UTF-8 locale."
             )
             return 2


### PR DESCRIPTION
... which lead to "Please set your system _touse_ a UTF-8 locale." 
By the way: Is it by purpose that sentences end with double spaces? 