### PR TITLE
much non-utf8 terminal support

### DIFF
--- a/doge/core.py
+++ b/doge/core.py
@@ -2,6 +2,7 @@
 # coding: utf-8
 
 import datetime
+import locale
 import os
 import sys
 import re
@@ -149,7 +150,18 @@ class Doge(object):
 
         with open(self.doge_path) as f:
             if sys.version_info < (3, 0):
-                doge_lines = [l.decode('utf-8') for l in f.xreadlines()]
+                if locale.getpreferredencoding() == 'UTF-8':
+                    doge_lines = [l.decode('utf-8') for l in f.xreadlines()]
+                else:
+                    # encode to printable characters, leaving a space in place
+                    # of untranslatable characters, resulting in a slightly
+                    # blockier doge on non-UTF8 terminals
+                    doge_lines = [
+                        l.decode('utf-8')
+                        .encode(locale.getpreferredencoding(), 'replace')
+                        .replace('?', ' ')
+                        for l in f.xreadlines()
+                    ]
             else:
                 doge_lines = [l for l in f.readlines()]
             return doge_lines


### PR DESCRIPTION
Translates doge output to something slightly blockier on non-utf8 terminals. Fixes #55.

Tested under:

* uxterm (LANG=fr_FR LC_ALL=fr_FR.utf8) [utf8 output not affected]
* xterm (LANG=en_US)

Python 2.7.11

Here it is running on a latin1 terminal:

![screenshot-2016-0105-1041](https://cloud.githubusercontent.com/assets/615684/12121061/fa14fb12-b398-11e5-8be0-4195c4229819.png)
